### PR TITLE
Fix incorrect keyword argument `key` with `conn_id`

### DIFF
--- a/doc_source/troubleshooting.md
+++ b/doc_source/troubleshooting.md
@@ -171,8 +171,8 @@ def get_variable(self, key):
 ```
 
 ```
-def get_conn_uri(self, key):
-  return self._get_secret('airflow/connections2', key)
+def get_conn_uri(self, conn_id):
+  return self._get_secret('airflow/connections2', conn_id)
   SecretsManagerBackend.get_conn_uri=get_conn_uri
 ```
 


### PR DESCRIPTION
*Issue #, if available:*
When replacing `get_conn_id` with your own implementation as shown in the example, it will fail:
```python
TypeError: get_conn_uri() got an unexpected keyword argument 'conn_id'
```
*Description of changes:*
`get_conn_uri` uses the keyword argument `conn_id`, not `key`. When using `key`, the underlying code will not work. Somewhere in Airflow, the conn_id will be passed as `get_conn_uri(conn_id=conn_id)`.

Therefore, replace `key` with `conn_id`.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
