### PR TITLE
missing "use"

### DIFF
--- a/doc_source/vpc-vpe-access.md
+++ b/doc_source/vpc-vpe-access.md
@@ -109,7 +109,7 @@ If you've chosen the **Private network** access mode for your Apache Airflow *We
 
 ## Accessing the VPC endpoint for your Apache Airflow Web server \(private network access\)<a name="vpc-vpe-access-endpoints"></a>
 
-If you've chosen the **Private network** access mode for your Apache Airflow *Web server*, you'll need to create a mechanism to access the VPC interface endpoint for your Apache Airflow *Web server*\. You must the same Amazon VPC, VPC security group, and private subnets as your Amazon MWAA environment for these resources\.
+If you've chosen the **Private network** access mode for your Apache Airflow *Web server*, you'll need to create a mechanism to access the VPC interface endpoint for your Apache Airflow *Web server*\. You must use the same Amazon VPC, VPC security group, and private subnets as your Amazon MWAA environment for these resources\.
 
 ### Using an AWS Client VPN<a name="vpc-vpe-access-vpn"></a>
 


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The statement is missing a "use" word


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
