### PR TITLE
Public IPv4 DNS Readme correction

### DIFF
--- a/doc_source/tutorials-private-network-bastion.md
+++ b/doc_source/tutorials-private-network-bastion.md
@@ -108,7 +108,7 @@ The following steps describe how to create the ssh tunnel to your linux bastion\
 
 1. Choose an instance\.
 
-1. Copy the address in **Public IPv4 DNS**\. For example, `ip-10-192-11-219.ec2.internal`\.
+1. Copy the address in **Public IPv4 DNS**\. For example, `ec2-4-82-142-1.compute-1.amazonaws.com`\.
 
 1. In your command prompt, navigate to the directory where your SSH key is stored\.
 
@@ -127,7 +127,7 @@ The following steps describe how to create the ssh tunnel to your linux bastion\
 
 1. Choose an instance\.
 
-1. Copy the address in **Public IPv4 DNS**\. For example, `ip-10-192-11-219.ec2.internal`\.
+1. Copy the address in **Public IPv4 DNS**\. For example, `ec2-4-82-142-1.compute-1.amazonaws.com`\.
 
 1. Open [PuTTY](https://www.putty.org/), select **Session**\.
 


### PR DESCRIPTION
`ip-10-192-11-219.ec2.internal` was currently given as an example to Public IPv4 DNS in two different occasions, which we all know is the Private DNS and not the Public DNS.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
