### PR TITLE
print statement missing create-web-login-token.py

### DIFF
--- a/doc_source/call-mwaa-apis-web.md
+++ b/doc_source/call-mwaa-apis-web.md
@@ -127,7 +127,7 @@ The following example uses the [boto3 create\_web\_login\_token](https://boto3.a
    webToken = response["WebToken"]
    airflowUIUrl = 'https://{0}/aws_mwaa/aws-console-sso?login=true#{1}'.format(webServerHostName, webToken)
    print("Here is your Airflow UI URL: ")
-   airflowUIUrl
+   print(airflowUIUrl)
    ```
 
 1. Substitute the placeholder in *red* for `YOUR_ENVIRONMENT_NAME`\.


### PR DESCRIPTION
The example create-web-login-token.py is about to print the url generated.

*Issue #, if available:*

*Description of changes:*
Just adding the print statement

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
