### PR TITLE
Add PythonOperator import for Airflow v2.0.2  sample code

### DIFF
--- a/doc_source/samples-database-cleanup.md
+++ b/doc_source/samples-database-cleanup.md
@@ -64,6 +64,7 @@ CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 from airflow import DAG, settings
  
 from airflow.providers.postgres.operators.postgres import PostgresOperator
+from airflow.operators.python_operator import PythonOperator
 from airflow.utils.dates import days_ago
 from airflow.jobs.base_job import BaseJob
 from airflow.models import DAG, DagModel, DagRun, ImportError, Log, SlaMiss, RenderedTaskInstanceFields, TaskFail, TaskInstance, TaskReschedule, Variable, XCom


### PR DESCRIPTION
Airflow 2.0.2 Code snippet fails for not finding PythonOperator

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
