### PR TITLE
Fix shell script create that needs ENVIRONMENT nam

### DIFF
--- a/doc_source/call-mwaa-apis-cli.md
+++ b/doc_source/call-mwaa-apis-cli.md
@@ -49,7 +49,7 @@ The following example uses a curl script to call the [create\-web\-login\-token]
 After copying it to your clipboard, you may need to use **Edit > Paste** from your shell menu\.
 
    ```
-   CLI_JSON=$(aws mwaa --region YOUR_REGION create-cli-token --name YOUR_HOST_NAME) \
+   CLI_JSON=$(aws mwaa --region YOUR_REGION create-cli-token --name YOUR_ENVIRONMENT_NAME) \
      && CLI_TOKEN=$(echo $CLI_JSON | jq -r '.CliToken') \
      && WEB_SERVER_HOSTNAME=$(echo $CLI_JSON | jq -r '.WebServerHostname') \
      && CLI_RESULTS=$(curl --request POST "https://$WEB_SERVER_HOSTNAME/aws_mwaa/cli" \
@@ -85,7 +85,7 @@ After copying it to your clipboard, you may need to use **Edit > Paste** from yo
 After copying it to your clipboard, you may need to use **Edit > Paste** from your shell menu\.
 
    ```
-   CLI_JSON=$(aws mwaa --region YOUR_REGION create-cli-token --name YOUR_HOST_NAME) \
+   CLI_JSON=$(aws mwaa --region YOUR_REGION create-cli-token --name YOUR_ENVIRONMENT_NAME) \
      && CLI_TOKEN=$(echo $CLI_JSON | jq -r '.CliToken') \
      && WEB_SERVER_HOSTNAME=$(echo $CLI_JSON | jq -r '.WebServerHostname') \
      && CLI_RESULTS=$(curl --request POST "https://$WEB_SERVER_HOSTNAME/aws_mwaa/cli" \


### PR DESCRIPTION
*Issue #, if available:*
In the sample shell command there is an error when creating cli token. This needs environment name and not host name.
*Description of changes:*
Replace YOUR_HOST_NAME with YOUR_ENVIRONMENT_NAME

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
