### PR TITLE
Fix erroneous closed brace in code example

### DIFF
--- a/doc_source/connections-secrets-manager.md
+++ b/doc_source/connections-secrets-manager.md
@@ -47,8 +47,7 @@ The [execution role](mwaa-create-role.md) for your Amazon MWAA environment needs
                 "secretsmanager:DescribeSecret",
                 "secretsmanager:ListSecretVersionIds"
             ],
-            "Resource": "arn:aws:secretsmanager:us-west-2:012345678910:secret:*",
-            }
+            "Resource": "arn:aws:secretsmanager:us-west-2:012345678910:secret:*"
         },
         {
             "Effect": "Allow",


### PR DESCRIPTION
*Issue #, if available:*

*Description of changes:* The example of the policy corrected in this PR had a typo which included an erroneous `}` 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
