### PR TITLE
Update configuring-dag-import-plugins.md

### DIFF
--- a/doc_source/configuring-dag-import-plugins.md
+++ b/doc_source/configuring-dag-import-plugins.md
@@ -101,6 +101,7 @@ COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER LIABILITY, WHETHER
 IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM, OUT OF OR IN
 CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE SOFTWARE.
 """
+import os
 from airflow.plugins_manager import AirflowPlugin
 import airflow.utils.python_virtualenv 
 from typing import List
@@ -114,6 +115,7 @@ def _generate_virtualenv_cmd(tmp_dir: str, python_bin: str, system_site_packages
     return cmd
 
 airflow.utils.python_virtualenv._generate_virtualenv_cmd=_generate_virtualenv_cmd
+os.environ["PATH"] = f"/usr/local/airflow/.local/bin:{os.environ['PATH']}"
 
 class VirtualPythonPlugin(AirflowPlugin):                
     name = 'virtual_python_plugin'


### PR DESCRIPTION
Airflow uses shutil.which to look for virtualenv. The installed virtualenv via requirements.txt isn't on the PATH. Adding the path to virtualenv to PATH solves this.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
