### PR TITLE
Fix typo in example code

### DIFF
--- a/doc_source/samples-ecs-operator.md
+++ b/doc_source/samples-ecs-operator.md
@@ -272,7 +272,6 @@ To use the sample code on this page, you'll need the following:
 1. Copy the contents of the following code sample and save locally as `mwaa-ecs-operator.py`, then upload your new DAG to Amazon S3\.
 
    ```
-   from http import client
    from airflow import DAG
    from airflow.providers.amazon.aws.operators.ecs import ECSOperator
    from airflow.utils.dates import days_ago


### PR DESCRIPTION
*Issue #, if available:* None

*Description of changes:*

Hi. While reading through the documentation, I found a typo in the example code. The first line of code imports `client` from Python's built-in `http` module. However, it is not used anywhere at all as `client` is replaced right away with `boto3.clients('ecs')`. I think whoever wrote this example code added the first line by accident, through editor auto-import feature.

By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
