### PR TITLE
Fix invalid s3:ListAllMyBuckets permissions

### DIFF
--- a/doc_source/mwaa-create-role.md
+++ b/doc_source/mwaa-create-role.md
@@ -171,10 +171,7 @@ The following example shows an execution role policy you can use for an [Custome
         { 
             "Effect": "Deny",
             "Action": "s3:ListAllMyBuckets",
-            "Resource": [
-                "arn:aws:s3:::{your-s3-bucket-name}",
-                "arn:aws:s3:::{your-s3-bucket-name}/*"
-            ]
+            "Resource": "*"
         }, 
         { 
             "Effect": "Allow",
@@ -318,10 +315,7 @@ The following example shows an execution role policy you can use for an [AWS own
         { 
             "Effect": "Deny",
             "Action": "s3:ListAllMyBuckets",
-            "Resource": [
-                "arn:aws:s3:::{your-s3-bucket-name}",
-                "arn:aws:s3:::{your-s3-bucket-name}/*"
-            ]
+            "Resource": "*"
         },
         { 
             "Effect": "Allow",

--- a/doc_source/mwaa-eks-example.md
+++ b/doc_source/mwaa-eks-example.md
@@ -158,10 +158,7 @@ Create a new role for the Amazon MWAA environment using the steps in [Amazon MWA
         {
             "Effect": "Deny",
             "Action": "s3:ListAllMyBuckets",
-            "Resource": [
-                "arn:aws:s3:::{MWAA_S3_BUCKET}",
-                "arn:aws:s3:::{MWAA_S3_BUCKET}/*"
-            ]
+            "Resource": "*"
         },
         {
             "Effect": "Allow",

--- a/doc_source/quick-start.md
+++ b/doc_source/quick-start.md
@@ -376,9 +376,7 @@ The AWS Command Line Interface \(AWS CLI\) is an open source tool that enables y
                 - !Sub "arn:aws:airflow:${AWS::Region}:${AWS::AccountId}:environment/${EnvironmentName}"
             - Effect: Deny
               Action: s3:ListAllMyBuckets
-              Resource:
-                - !Sub "${EnvironmentBucket.Arn}"
-                - !Sub "${EnvironmentBucket.Arn}/*"
+              Resource: "*"
   
             - Effect: Allow
               Action:


### PR DESCRIPTION
All of the `s3:ListAllMyBuckets` permissions incorrectly specified s3 arns for the `Resource`. I changed them all to `"*"` which is the only valid `Resource` for that `Action`.


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
