### PR TITLE
Update script to match the filename previously created

### DIFF
--- a/doc_source/samples-ecs-operator.md
+++ b/doc_source/samples-ecs-operator.md
@@ -238,7 +238,7 @@ To use the sample code on this page, you'll need the following:
       securityGroupId=$(echo "$response" | jq -r '.Environment.NetworkConfiguration.SecurityGroupIds[]')
       subnetIds=$(joinByString '\,' $(echo "$response" | jq -r '.Environment.NetworkConfiguration.SubnetIds[]'))
       
-      aws cloudformation create-stack --stack-name $2 --template-body file://ecs-cfn.json \
+      aws cloudformation create-stack --stack-name $2 --template-body file://ecs-mwaa-cfn.json \
       --parameters ParameterKey=SecurityGroups,ParameterValue=$securityGroupId \
       ParameterKey=SubnetIds,ParameterValue=$subnetIds \
       --capabilities CAPABILITY_IAM


### PR DESCRIPTION
Fix a typo in the filename of the previously created configuration template. 


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
