### PR TITLE
convert `json_dictionary` to string before appending it to a string.

### DIFF
--- a/doc_source/samples-variables-import.md
+++ b/doc_source/samples-variables-import.md
@@ -68,7 +68,7 @@ try:
         json_dictionary = json.loads(fileconf)
         for key in json_dictionary:
             print(key, " ", json_dictionary[key])
-            val = (key + " " + json_dictionary[key])
+            val = (key + " " + str(json_dictionary[key]))
             mwaa_auth_token = 'Bearer ' + mwaa_cli_token['CliToken']
             mwaa_webserver_hostname = 'https://{0}/aws_mwaa/cli'.format(mwaa_cli_token['WebServerHostname'])
             raw_data = "variables set {0}".format(val)


### PR DESCRIPTION
Even with this conversion, this code is working for single-string values like this "key": "value" but not for this {"key": { "inside_key": "inside_value"}}.

*Issue #, if available:*

*Description of changes:*


By submitting this pull request, I confirm that you can use, modify, copy, and redistribute this contribution, under the terms of your choice.
